### PR TITLE
Listen for keyup

### DIFF
--- a/jquery.ziptastic.js
+++ b/jquery.ziptastic.js
@@ -23,7 +23,7 @@
 		return this.each(function() {
 			var ele = $(this);
 
-			ele.on('input change', function() {
+			ele.on('keyup', function() {
 				var zip = ele.val();
 
 				// TODO Non-US zip codes?


### PR DESCRIPTION
In my usage of the original code base, typing into a zip field would fire an "input" event for each character I entered. After the 5th digit, the zipChange event would fire and json would return. However, if I clicked away (another form field or anywhere else on the page) the "change" event would fire and another ajax request would fire, returning the same json block.

Instead of listening for "input" and "change", my change just listens for "keyup".
