### PR TITLE
Fix local demo.html.

### DIFF
--- a/jquery.ziptastic.js
+++ b/jquery.ziptastic.js
@@ -18,7 +18,13 @@
 			requests[country] = {};
 		}
 		if(!requests[country][zip]) {
-			requests[country][zip] = $.getJSON(location.protocol + '//zip.getziptastic.com/v2/' + country + '/' + zip);
+			var protocol = '';
+			if (location.protocol == 'file:') {
+				protocol = 'https://';
+			} else {
+				protocol = location.protocol;
+			}
+			requests[country][zip] = $.getJSON(protocol + '//zip.getziptastic.com/v2/' + country + '/' + zip);
 		}
 
 		// Bind to the finished request


### PR DESCRIPTION
Since I was using `location.protocol` to match http and https when calling the API endpoint it was failing when just cloning the repository and opening up demo.html in a browser.

Resulting in an attempt by the browser to access `file://zip.getziptastic.com` which obviously doesn't exist.

![screen shot 2016-06-18 at 1 16 08 pm](https://cloud.githubusercontent.com/assets/192456/16172432/edf05a6c-3556-11e6-88e0-57391dbd1b3a.png)
